### PR TITLE
added script to run eap-proxy on reboot, updated README for same

### DIFF
--- a/10-run-eap-proxy.sh
+++ b/10-run-eap-proxy.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+if podman ps -a | grep eap_proxy &>/dev/null; then
+    podman start eap_proxy-udmpro
+else
+    podman run --privileged --network=host --name=eap_proxy-udmpro --log-driver=k8s-file --restart always -d -ti pbrah/eap_proxy-udmpro:v1.1 --update-mongodb --ping-gateway --ignore-when-wan-up --ignore-start --ignore-logoff --set-mac eth8 eth9
+fi

--- a/README.md
+++ b/README.md
@@ -6,7 +6,13 @@ For v1.6.3 and newer you need to run your container with podman instead which ch
 podman run --privileged --network=host --name=eap_proxy-udmpro --log-driver=k8s-file --restart always -d -ti pbrah/eap_proxy-udmpro:v1.1 --update-mongodb --ping-gateway --ignore-when-wan-up --ignore-start --ignore-logoff --set-mac eth8 eth9
 ```
 
+You also may want to have this automatically come back up after a reboot. Assuming you've already installed [the on-boot script from unifi-utilities/unifios-utilities](https://github.com/unifi-utilities/unifios-utilities/blob/main/on-boot-script/README.md#install), place the included `10-run-eap-proxy.sh` into `/mnt/data/on_boot.d/` on your UDMP. 
+
 ## **Changelog**
+
+*v1.2*
+* added a script for persistence on reboot
+
 *v1.1*
 * added option **--update-mongodb** for UDM Pro users to avoid the lost Unifi controller bug
 * Created a fixit.py to manually fix the database


### PR DESCRIPTION
* Fixes the `Error: error creating container storage: the container name "eap_proxy-udmpro" is already in use` error seen when trying to restart this by adding a small script that allows the script to persist across reboots without interfering with the `--restart` flag.
* Could alternatively remove the explicit name and pass the `--rm` flag.